### PR TITLE
Feat/add on release trigger for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main]
 
+  release:
+    types: [published]
+
   workflow_dispatch:
 
 concurrency:

--- a/src/workflows/build.yml
+++ b/src/workflows/build.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main]
 
+  release:
+    types: [published]
+
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Purpose

This change allow to build release tags for pinned version deployement

